### PR TITLE
Move directive notes

### DIFF
--- a/website/docs/atmo/concepts/the-directive.md
+++ b/website/docs/atmo/concepts/the-directive.md
@@ -19,10 +19,10 @@ handlers:
     method: POST
     steps:
       - group:
-          - fn: modify-url
-          - fn: helloworld-rs
-            onErr:
-              any: continue
+        - fn: modify-url
+        - fn: helloworld-rs
+          onErr:
+            any: continue
 
       - fn: fetch
 

--- a/website/docs/atmo/concepts/the-directive.md
+++ b/website/docs/atmo/concepts/the-directive.md
@@ -2,6 +2,10 @@
 
 The Directive is a declarative file that allows you to describe your application's business logic. By describing your application declaratively, you can avoid all of the boilerplate code that normally comes with building a web service such as binding to ports, setting up TLS, constructing a router, etc.
 
+:::note
+`subo` will validate your Directive to help ensure that it is correct.
+:::
+
 Here's an example Directive:
 
 ```yaml
@@ -38,8 +42,3 @@ handlers:
 This directive encapsulates all of the logic for your application. It describes three endpoints and the logic needed to handle them. Each handler describes a set of `steps` that composes a series of Runnables to handle the request.
 
 Atmo uses the Directive to build your application and run it automatically, without any need to write boilerplate yourself.
-
-:::note
-`subo` will validate your directive to help ensure that your Directive is correct,
-including validating that you're not accessing keys that don't exist in state.
-:::

--- a/website/docs/atmo/concepts/the-directive.md
+++ b/website/docs/atmo/concepts/the-directive.md
@@ -15,10 +15,10 @@ handlers:
     method: POST
     steps:
       - group:
-        - fn: modify-url
-        - fn: helloworld-rs
-          onErr:
-            any: continue
+          - fn: modify-url
+          - fn: helloworld-rs
+            onErr:
+              any: continue
 
       - fn: fetch
 
@@ -39,3 +39,7 @@ This directive encapsulates all of the logic for your application. It describes 
 
 Atmo uses the Directive to build your application and run it automatically, without any need to write boilerplate yourself.
 
+:::note
+`subo` will validate your directive to help ensure that your Directive is correct,
+including validating that you're not accessing keys that don't exist in state.
+:::

--- a/website/docs/atmo/usage/managing-state.md
+++ b/website/docs/atmo/usage/managing-state.md
@@ -69,6 +69,6 @@ that looks like this:
 }
 ```
 
-`subo` will validate your directive to help ensure that your Directive is correct, 
+As outlined in the [Directive page](../concepts/the-directive.md), `subo` will automatically validate your Directive,
 including validating that you're not accessing keys that don't exist in state.
 


### PR DESCRIPTION
This closes #33 

This adjusts the wording so that the automatic Directive validation is on the Directive page