### PR TITLE
Add dockerfile for deployment builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Resources:
+# https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+# https://sws.joseluisq.net/features/docker/
+
+# Build stage for generating the static build
+FROM node:16 as builder
+
+WORKDIR /tmp/docubuild
+
+# Leverage build cache for installed npm packages
+COPY website/package*.json ./website/
+
+WORKDIR website
+RUN npm install
+
+# TODO: maybe use ci (do we need the dev dependencies?)
+# RUN npm ci --only=production
+
+# Copy docs sources
+COPY website .
+
+# Docusaurus needs the .git history for e.g. contributor attributions
+COPY .git ../.git
+
+# Generate static build in website/build
+RUN npm run build
+
+
+# Stripped-down Static Web Server container for serving the files
+FROM joseluisq/static-web-server:2
+
+# Copy generated static build over from builder stage
+COPY --from=builder /tmp/docubuild/website/build /public


### PR DESCRIPTION
This Dockerfile adds efficient multistage builds to generate the static build of the docs and serve it using a minimal stripped down static server.

To build and run:

```
docker build . -t subo/docs
docker run -p 8080:80 subo/docs
``

After which the docs should be served on http://localhost:8080