### PR TITLE
Spruce up project URIs and add project logos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,9 @@ WORKDIR /tmp/docubuild
 # Leverage build cache for installed npm packages
 COPY website/package*.json ./website/
 
-WORKDIR website
-RUN npm install
+WORKDIR /tmp/docubuild/website
 
-# TODO: maybe use ci (do we need the dev dependencies?)
-# RUN npm ci --only=production
+RUN npm install
 
 # Copy docs sources
 COPY website .
@@ -26,9 +24,8 @@ COPY .git ../.git
 # Generate static build in website/build
 RUN npm run build
 
-
-# Stripped-down Static Web Server container for serving the files
-FROM joseluisq/static-web-server:2
+# Webserver for serving static files
+FROM caddy:2
 
 # Copy generated static build over from builder stage
-COPY --from=builder /tmp/docubuild/website/build /public
+COPY --from=builder /tmp/docubuild/website/build /usr/share/caddy

--- a/website/docs/atmo/atmo.md
+++ b/website/docs/atmo/atmo.md
@@ -2,7 +2,11 @@
 pagination_prev: null
 ---
 
-# About Atmo
+# Atmo
+
+### The application framework for cloud native WebAssembly
+
+![](/img/logo-atmo-wide.svg)
 
 Atmo is an application framework for cloud native WebAssembly. It allows you to build polyglot server apps that execute in a high performance sandboxed execution engine. Atmo applications are comprised of functions compiled into WebAssembly modules from various languages
 such as JavaScript, Rust Go, and Grain.

--- a/website/docs/compute/compute.md
+++ b/website/docs/compute/compute.md
@@ -1,4 +1,11 @@
-# About Suborbital Compute
+---
+pagination_prev: null
+---
+# Suborbital Compute
+
+### The SaaS extensibility platform
+
+![](/img/suborbital-logo-wide.svg)
 
 Suborbital Compute is a platform that allows your users to write and deploy serverless extensions for your app so they can develop custom integrations, customizations, and workflows. Our WebAssembly-based compute core lets you run user code within your infrastructure while being sure that you're protected from malicious code.
 

--- a/website/docs/grav/grav.md
+++ b/website/docs/grav/grav.md
@@ -1,4 +1,12 @@
-# What is Grav?
+---
+pagination_prev: null
+---
+
+# Grav
+
+### The distributed async message bus for Go
+
+![](/img/SOS_Grav-Long-FullColour.svg)
 
 Grav is an embedded distributed messaging library for Go applications 
 that allows interconnected components of your system to communicate 

--- a/website/docs/reactr/reactr.md
+++ b/website/docs/reactr/reactr.md
@@ -1,4 +1,12 @@
-# Get started with Reactr 🚀
+---
+pagination_prev: null
+---
+
+# Reactr
+
+### The next-gen function scheduler for Go and WebAssembly
+
+![](/img/SOS_Reactr-Long-FullColour0.svg)
 
 ### The Basics
 

--- a/website/docs/sat/sat.md
+++ b/website/docs/sat/sat.md
@@ -2,7 +2,11 @@
 pagination_prev: null
 ---
 
-# About Sat
+# Sat
+
+### The tiny but mighty WebAssembly edge compute server
+
+![](/img/logo-sat-wide.svg)
 
 Sat is a WebAssembly-powered server designed to have the maximum performance and smallest possible footprint. Our [Atmo](https://github.com/suborbital/atmo) project is a fully-fledged platform with support for running entire applications, whereas Sat takes the opposite approach: run a single Wasm module blazing fast!
 

--- a/website/docs/subo/subo.md
+++ b/website/docs/subo/subo.md
@@ -1,6 +1,12 @@
-# Subo, the Suborbital CLI
+---
+pagination_prev: null
+---
 
-Subo is the command-line helper for working with the Suborbital Development Platform. Subo is used to build Wasm Runnables, generate new projects and config files, and more over time.
+# Subo
+
+### The Suborbital CLI
+
+Subo is the command-line tool for working with the Suborbital Development Platform. Subo is used to build Wasm Runnables, generate new projects and config files, and more over time.
 
 **You do not need to install language-specific tools to get started with WebAssembly and Subo!** A Docker toolchain is supported (see below) that can build your Runnables without needing to install language toolchains.
 

--- a/website/docs/subo/usage.md
+++ b/website/docs/subo/usage.md
@@ -1,4 +1,4 @@
-# Get started
+# Usage
 
 Subo includes the WebAssembly toolchain for Suborbital projects.
 

--- a/website/docs/vektor/vektor.md
+++ b/website/docs/vektor/vektor.md
@@ -1,4 +1,12 @@
-# The Vektor Guide 🗺
+---
+pagination_prev: null
+---
+
+# Vektor
+
+### The opinionated, production-grade server framework for Go
+
+![](/img/SOS_Vektor-Long-FullColour.svg)
 
 Vektor's goal is to help you develop web services faster.
 Vektor handles much of the boilerplate needed to start

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -4,7 +4,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Intro to WebAssembly',
-      collapsible: false,
+      collapsible: true,
       items: [
         'intro-to-webassembly/history',
         'intro-to-webassembly/why-webassembly'
@@ -16,7 +16,7 @@ module.exports = {
       collapsible: true,
       link: {
         type: 'doc',
-        id: 'compute/what-is-compute',
+        id: 'compute/compute',
       },
       items: [
         {
@@ -61,7 +61,7 @@ module.exports = {
       collapsible: true,
       link: {
         type: 'doc',
-        id: 'atmo/about-atmo'
+        id: 'atmo/atmo'
       },
       items: [
         {
@@ -125,12 +125,23 @@ module.exports = {
       label: 'Sat',
       link: {
         type: 'doc',
-        id: 'sat/about-sat'
+        id: 'sat/sat'
       },
       items: [
         'sat/using-sat',
         'sat/building-sat',
         'sat/constellations',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Subo',
+      link: {
+        type: 'doc',
+        id: 'subo/subo'
+      },
+      items: [
+        'subo/usage',
       ]
     },
     {
@@ -143,7 +154,7 @@ module.exports = {
           label: 'Reactr',
           link: {
             type: 'doc',
-            id: 'reactr/guide'
+            id: 'reactr/reactr'
           },
           items: [
             {
@@ -163,13 +174,13 @@ module.exports = {
           label: 'Vektor',
           link: {
             type: 'doc',
-            id: 'vektor/getting-started'
+            id: 'vektor/vektor'
           },
           items: [
             {
               type: 'doc',
               label: 'Testing Vektor',
-              id: 'vektor/testing-vk-servers'
+              id: 'vektor/vektor'
             },
           ]
         },
@@ -178,7 +189,7 @@ module.exports = {
           label: 'Grav',
           link: {
             type: 'doc',
-            id: 'grav/what-is-grav'
+            id: 'grav/grav'
           },
           items: [
             {

--- a/website/src/components/sections/Header.jsx
+++ b/website/src/components/sections/Header.jsx
@@ -18,7 +18,7 @@ const Header = () => {
           Our WebAssembly-based compute core lets you run user code within your infrastructure while being sure that you're protected from malicious code.
         </Paragraph>
         <Row>
-          <Link to={useBaseUrl('compute/what-is-compute')}>
+          <Link to={useBaseUrl('compute')}>
             <DocButton>Get Started with Suborbital Compute</DocButton>
           </Link>
         </Row>

--- a/website/src/components/sections/data.js
+++ b/website/src/components/sections/data.js
@@ -4,14 +4,14 @@ export const FlagshipProjects = [
     icon: 'img/logo-atmo-wide.svg',
     heading: 'Atmo',
     description: 'Application framework for cloud native WebAssembly.',
-    url: 'atmo/about-atmo'
+    url: 'atmo'
   },
   {
     key: 'sat',
     icon: 'img/logo-sat-wide.svg',
     heading: 'Sat',
     description: 'Tiny & fast WebAssembly edge compute server.',
-    url: 'sat/about-sat'
+    url: 'sat'
   },
 
 ]
@@ -22,21 +22,21 @@ export const BuildingBlocks = [
     icon: 'img/SOS_Reactr-Long-FullColour0.svg',
     heading: 'Reactr',
     description: 'Function scheduler for Go and Wasm.',
-    url: 'reactr/guide'
+    url: 'reactr'
   },
   {
     key: 'vektor',
     icon: 'img/SOS_Vektor-Long-FullColour.svg',
     heading: 'Vektor',
     description: 'Opinionated server framework for Go.',
-    url: 'vektor/getting-started'
+    url: 'vektor'
   },
   {
     key: 'grav',
     icon: 'img/SOS_Grav-Long-FullColour.svg',
     heading: 'Grav',
     description: 'Async message bus for Go.',
-    url: 'grav/what-is-grav'
+    url: 'grav'
   },
 ]
 


### PR DESCRIPTION
This standardizes each project's URI (/compute, /atmo, /sat etc)

It also adds project logos to their main page and adds Subo to the sidebar.