### PR TITLE
Runnable examples: Replace Swift with JS

### DIFF
--- a/website/docs/atmo/usage/creating-runnables.md
+++ b/website/docs/atmo/usage/creating-runnables.md
@@ -10,10 +10,10 @@ You can create a new Runnable with subo:
 subo create runnable myfunction
 ```
 
-By default, Rust will be used. To use Swift, pass `--lang`:
+By default, Rust will be used. To use JavaScipt, pass `--lang`:
 
 ```bash
-subo create runnable myswiftfunction --lang=swift
+subo create runnable myjavascriptfunction --lang=javascript
 ```
 
 Each runnable has a `.runnable.yaml` that describes it.

--- a/website/docs/atmo/usage/creating-runnables.md
+++ b/website/docs/atmo/usage/creating-runnables.md
@@ -10,7 +10,7 @@ You can create a new Runnable with subo:
 subo create runnable myfunction
 ```
 
-By default, Rust will be used. To use JavaScipt, pass `--lang`:
+By default, Rust will be used. To use JavaScript, pass `--lang`:
 
 ```bash
 subo create runnable myjavascriptfunction --lang=javascript


### PR DESCRIPTION
Closes #30

This replaces our Swift alternative language example with JavaScript