### PR TITLE
Make docker output non-copiable

### DIFF
--- a/website/docs/atmo/get-started.md
+++ b/website/docs/atmo/get-started.md
@@ -63,7 +63,7 @@ subo build .
 This automatically compiles each of your Runnables in a Docker container and bundles
 them together in `runnables.wasm.zip` to be used in Atmo.
 
-```text
+```no-copy
 ⏩ START: building runnables in .
 ℹ️  🐳 using Docker toolchain
 ⏩ START: building runnable: helloworld (rust)

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -10,6 +10,14 @@
   src: url('/static/Montserrat-Regular.ttf') format('ttf');
 }
 
+/**
+ * Code blocks without copy button, credit to:
+ * https://stackoverflow.com/a/70770033
+ */
+.no-copy button {
+  display: none;
+}
+
 :root {
   --ifm-color-primary: #0e4e87;
   --ifm-color-secondary: #57c5af;


### PR DESCRIPTION
Closes #53 

Thanks to @LauraLangdon's suggestion, this removes the copy button from the docker output in the Atmo "Getting Started" section.