### PR TITLE
docs: fix broken link to getting start page

### DIFF
--- a/website/docs/subo/subo.md
+++ b/website/docs/subo/subo.md
@@ -35,7 +35,7 @@ subo --help
 
 
 ## Getting started
-**To get started with Subo, visit the [Get started guide](./docs/get-started.md).**
+**To get started with Subo, visit the [Get started guide](./atmo/get-started.md).**
 
 ## Builders
 This repo contains builders for the various languages supported by Wasm Runnables. A builder is a Docker image that can build Runnables into Wasm modules, and is used internally by `subo` to build your code! See the [builders](./builder/docker) directory for more.


### PR DESCRIPTION
Switched the "Getting Started" link so it points to the Atmo one instead of a non-existent subo one. h/t to @ramonh for figuring that was all that was needed! This will close Issue #76.