### PR TITLE
Fix subo README table formatting

### DIFF
--- a/website/docs/subo/subo.md
+++ b/website/docs/subo/subo.md
@@ -42,6 +42,7 @@ This repo contains builders for the various languages supported by Wasm Runnable
 
 ## Platforms
 The `subo` tool supports the following platforms and operating systems:
+
 |  | x86_64 | arm64
 | --- | --- | --- |
 | Mac | ✅ | ✅ |
@@ -49,6 +50,7 @@ The `subo` tool supports the following platforms and operating systems:
 | Windows | 🚫 | 🚫 |
  
 The language toolchains used by `subo` support the following platforms:
+
 | | x86_64 | arm64 | Docker |
 | --- | --- | --- | --- |
 | Rust | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Closes #80 

I've often found that moving docs from Github to other has the side-effect of messing up some formatting that's fixed by adding an extra newline 👀 