### PR TITLE
docs: adding contributing guidelines info

### DIFF
--- a/website/docs/contributing-guide/contributing-to-suborbital.md
+++ b/website/docs/contributing-guide/contributing-to-suborbital.md
@@ -26,7 +26,16 @@ the label good-first-issues.
 If you're not yet ready to start contributing code, but notice
 something that requires work please report it against the 
 appropriate repository. For example, any documentation-related
-issue needs to be filed against the suborbital/docs repository.
+issue needs to be filed against the [suborbital/docs repository](https://github.com/suborbital/docs).
+
+## Contributing Guidelines
+There are two rules that must be adhered to when making contributions:
+
+1. All interaction with Suborbital on GitHub or in other public online spaces such as [Discord](https://chat.suborbital.dev) or [Twitter](https://twitter.com/suborbitaldev) must follow the [Contributor Covenant Code of Conduct](https://github.com/suborbital/meta/blob/master/CODE_OF_CONDUCT.md) which is kept up to date in the [`suborbital/meta` repository](https://github.com/suborbital/meta).
+
+2. Any code contributions must be preceded by a discussion that takes place in a GitHub issue for the associated repo(s). Please do not submit Pull Requests before first creating an issue and discussing it with the Suborbital team or using an existing issue. This includes all changes to the contents of Suborbital Git repositories, except for the following content: documentation, README errors, additional automated tests, and additional clarifying information such as comments. The Suborbital team can choose to close any Pull Request that does not have an appropriate issue.
+
+Beyond all else please be kind, and welcome to the Suborbital family of projects! We're really glad you're here.
 
 
 

--- a/website/docs/contributing/contributing-to-suborbital.md
+++ b/website/docs/contributing/contributing-to-suborbital.md
@@ -1,0 +1,32 @@
+# Contributing to Suborbital
+
+## Your very first contribution
+
+### Find something to work on
+
+The very first step towards contributing to Suborbital
+is to find something to work on. No contribution is
+small and help is always required!
+
+Here are some great avenues to help you get going
+on your contribution journey
+
+- Help improve the documentation for various Suborbital projects
+- Help triage issues
+
+### Find a good first issue
+
+There are multiple repositories within the Suborbital
+organization. Each repository has issues that are 
+beginner-friendly and can be accessed by filtering with
+the label good-first-issues.
+
+### Filing an issue
+
+If you're not yet ready to start contributing code, but notice
+something that requires work please report it against the 
+appropriate repository. For example, any documentation-related
+issue needs to be filed against the suborbital/docs repository.
+
+
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -229,7 +229,7 @@ module.exports = {
         }
       ]
     },
-    'contributing-guide/contributing-to-suborbital'
+    'contributing/contributing-to-suborbital'
   ]
 }
 


### PR DESCRIPTION
Changed the main category url for the contributing page as requested in PR #93: https://github.com/suborbital/docs/pull/93#issuecomment-1078579469