### PR TITLE
fix: add default language (fixes #73)

### DIFF
--- a/website/extensions/mlc.jsx
+++ b/website/extensions/mlc.jsx
@@ -100,7 +100,7 @@ const reactrLanguageStatusBadges = (status) => {
 
 export const MultiLanguageCodeBlock = ({children}) => (
     <>
-        <Tabs groupId="reactr-language" defaultValue={null}>
+        <Tabs groupId="reactr-language" defaultValue={getCodeBlockLangs(children)?.[0].lang ?? null}>
             {getCodeBlockLangs(children).map(
                 ({lang,name,status}) =>
                     <TabItem


### PR DESCRIPTION
I'm not *entirely* sure why we were setting the `defaultLang` prop explicitly `null` (maybe React was complaining? or it was clashing?), but this fix sets the first tab as the default language for MultiLanguageCodeBlocks (this is the default when using `<Tabs>` on their own).