### PR TITLE
docs: make contributing a sidebar category

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -229,6 +229,16 @@ module.exports = {
         }
       ]
     },
-    'contributing/contributing-to-suborbital'
+    {
+      type: 'category',
+      label: 'Contributing to Suborbital',
+      link: {
+        type: 'doc',
+        id: 'contributing/contributing-to-suborbital'
+      },
+      items: [
+        'contributing/contributing-to-suborbital',
+      ]
+    },
   ]
 }


### PR DESCRIPTION
My previous attempt at pushing this somehow included a bunch of extraneous commits. Anyway, I just made "Contributing to Suborbital" a category in the docs sidebar to close Issue #97.