### PR TITLE
fix: correct URL for sat examples

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -372,7 +372,6 @@ Runnables
 runtime
 Runtime
 RVG
-rwasm
 SaaS
 sandboxed
 scalable

--- a/website/docs/contributing/contributing-to-suborbital.md
+++ b/website/docs/contributing/contributing-to-suborbital.md
@@ -17,25 +17,23 @@ on your contribution journey
 ### Find a good first issue
 
 There are multiple repositories within the Suborbital
-organization. Each repository has issues that are 
+organization. Each repository has issues that are
 beginner-friendly and can be accessed by filtering with
 the label good-first-issues.
 
 ### Filing an issue
 
 If you're not yet ready to start contributing code, but notice
-something that requires work please report it against the 
+something that requires work please report it against the
 appropriate repository. For example, any documentation-related
 issue needs to be filed against the [suborbital/docs repository](https://github.com/suborbital/docs).
 
 ## Contributing Guidelines
+
 There are two rules that must be adhered to when making contributions:
 
-1. All interaction with Suborbital on GitHub or in other public online spaces such as [Discord](https://chat.suborbital.dev) or [Twitter](https://twitter.com/suborbitaldev) must follow the [Contributor Covenant Code of Conduct](https://github.com/suborbital/meta/blob/master/CODE_OF_CONDUCT.md) which is kept up to date in the [`suborbital/meta` repository](https://github.com/suborbital/meta).
+1. All interaction with Suborbital on GitHub or in other public online spaces such as [Discord](https://chat.suborbital.dev) or [Twitter](https://twitter.com/suborbitaldev) must follow the [Contributor Covenant Code of Conduct](https://github.com/suborbital/meta/blob/main/CODE_OF_CONDUCT.md) which is kept up to date in the [`suborbital/meta` repository](https://github.com/suborbital/meta).
 
 2. Any code contributions must be preceded by a discussion that takes place in a GitHub issue for the associated repo(s). Please do not submit Pull Requests before first creating an issue and discussing it with the Suborbital team or using an existing issue. This includes all changes to the contents of Suborbital Git repositories, except for the following content: documentation, README errors, additional automated tests, and additional clarifying information such as comments. The Suborbital team can choose to close any Pull Request that does not have an appropriate issue.
 
 Beyond all else please be kind, and welcome to the Suborbital family of projects! We're really glad you're here.
-
-
-

--- a/website/docs/reactr/reactr.md
+++ b/website/docs/reactr/reactr.md
@@ -11,12 +11,14 @@ pagination_prev: null
 ### The Basics
 
 First, install Reactr's core package `rt`:
+
 ```bash
 go get github.com/suborbital/reactr/rt
 ```
 
 And then get started by defining something `Runnable`:
-```golang
+
+```go
 package main
 
 import (
@@ -45,7 +47,8 @@ func (g generic) OnChange(change rt.ChangeEvent) error {
 A `Runnable` is something that can take care of a job - all it needs to do is conform to the `Runnable` interface as you see above.
 
 Once you have a Runnable, create a Reactr instance, register it, and `Do` some work:
-```golang
+
+```go
 package main
 
 import (
@@ -70,6 +73,7 @@ func main() {
 	fmt.Println("done!", res.(string))
 }
 ```
+
 When you `Do` some work, you get a `Result`. A result is like a Rust future or a JavaScript promise; it is something you can get the job's result from once it is finished.
 
 Calling `Then()` will block until the job is complete, and then give you the return value from the Runnable's `Run`. Cool, right?
@@ -77,6 +81,7 @@ Calling `Then()` will block until the job is complete, and then give you the ret
 ## Runnables pt. 2
 
 There are some more complicated things you can do with Runnables:
+
 ```go
 type recursive struct{}
 
@@ -112,21 +117,26 @@ if err != nil {
 
 fmt.Println("done!", res.(string))
 ```
+
 Will cause this output:
-```
+
+```console
 doing job: first
 doing job: second
 doing job: last
 done! finished last
 ```
+
 The ability to chain jobs is quite powerful!
 
 You won't always need or care about a job's output, and in those cases, make sure to call `Discard()` on the result to allow the underlying resources to be deallocated!
+
 ```go
 r.Do(r.Job("recursive", "first")).Discard()
 ```
 
 To do something asynchronously with the `Result` once it completes, call `ThenDo` on the result:
+
 ```go
 r.Do(r.Job("generic", "first")).ThenDo(func(res interface{}, err error) {
 	if err != nil {
@@ -136,11 +146,13 @@ r.Do(r.Job("generic", "first")).ThenDo(func(res interface{}, err error) {
 	//do something with the result
 })
 ```
+
 `ThenDo` will return immediately, and provided callback will be run on a background goroutine. This is useful for handling results that don't need to be consumed by your main program execution.
 
 ### Groups
 
 A reactr `Group` is a set of `Result`s that belong together. If you're familiar with Go's `errgroup.Group{}`, it is similar. Adding results to a group will allow you to evaluate them all together at a later time.
+
 ```go
 grp := rt.NewGroup()
 
@@ -152,14 +164,17 @@ if err := grp.Wait(); err != nil {
 	log.Fatal(err)
 }
 ```
+
 Will print:
-```
+
+```console
 doing job: first
 doing job: group work
 doing job: group work
 doing job: second
 doing job: last
 ```
+
 As you can see, the "recursive" jobs from the `generic` runner get queued up after the two jobs that don't recurse.
 
 Note that you cannot get result values from result groups, the error returned from `Wait()` will be the first error from any of the results in the group, if any. To get result values from a group of jobs, put them in an array and call `Then` on them individually.
@@ -167,7 +182,9 @@ Note that you cannot get result values from result groups, the error returned fr
 **TIP** If you return a group from a Runnable's `Run`, calling `Then()` on the result will recursively call `Wait()` on the group and return the error to the original caller! You can easily chain jobs and job groups in various orders.
 
 ### Pools
+
 Each `Runnable` that you register is given a worker to process their jobs. By default, each worker has one work thread processing jobs in sequence. If you want a particular worker to process more than one job concurrently, you can increase its `PoolSize`:
+
 ```go
 doGeneric := r.Register("generic", generic{}, rt.PoolSize(3))
 
@@ -180,9 +197,11 @@ if err := grp.Wait(); err != nil {
 	log.Fatal(err)
 }
 ```
+
 Passing `PoolSize(3)` will spawn three work threads to process `generic` jobs.
 
 ### Autoscaling pools
+
 By default, defining a pool size causes a static number of work threads to be started and will continue to run for the duration of the program's lifetime. If you have more variable workloads and need to scale your compute up and down to compensate, Reactr can handle that with the Autoscale option:
 
 ```go
@@ -192,11 +211,14 @@ for i := 0; i < 10000; i++ {
 	doGeneric("lots to do").Discard()
 }
 ```
+
 By passing the `rt.Autoscale` option, we indicate to Reactr that the worker should create and destroy threads as needed to handle the amount of work to be done. The parameter passed to Autoscale indicates the maximum number of threads. If you pass 0, it will default to the number of available CPUs.
 
 ### Timeouts
+
 By default, if a job becomes stuck and is blocking execution, it will block forever. If you want to have a worker time out after a certain amount of seconds on a stuck job, pass `rt.TimeoutSeconds` to Handle:
-``` golang
+
+```go
 h := rt.New()
 
 doTimeout := r.Register("timeout", timeoutRunner{}, rt.TimeoutSeconds(3))
@@ -204,7 +226,9 @@ doTimeout := r.Register("timeout", timeoutRunner{}, rt.TimeoutSeconds(3))
 When `TimeoutSeconds` is set and a job executes for longer than the provided number of seconds, the worker will move on to the next job and `ErrJobTimeout` will be returned to the Result. The failed job will continue to execute in the background, but its result will be discarded.
 
 ### Schedules
+
 The `r.Do` method will run your job immediately, but if you need to run a job at a later time, at a regular interval, or on some other schedule, then the `Schedule` interface will help. The `Schedule` interface allows for an object to choose when to execute a job. Any object that conforms to the interface can be used as a Schedule:
+
 ```go
 // Schedule is a type that returns an *optional* job if there is something that should be scheduled.
 // Reactr will poll the Check() method at regular intervals to see if work is available.
@@ -213,7 +237,9 @@ type Schedule interface {
 	Done() bool
 }
 ```
+
 The `r.Schedule` method will allow you to register a Schedule, and there are two built-in schedules(`Every` and `After`) to help:
+
 ```go
 r := rt.New()
 
@@ -224,22 +250,27 @@ r.Schedule(rt.Every(60*60, func() Job {
 	return NewJob("worker", nil)
 }))
 ```
+
 Reactr will poll all registered Schedules at a 1 second interval to `Check` for new jobs. Schedules can end their own execution by returning `false` from the `Done` method. You can use the Schedules provided with Reactr or develop your own.
 
 Scheduled jobs' results are discarded automatically using `Discard()`
 
 ### Advanced Runnables
 
-The `Runnable` interface defines an `OnChange` function which gives the Runnable a chance to prepare itself for changes to the worker running it. For example, when a Runnable is registered with a pool size greater than 1, the Runnable may need to provision resources for itself to enable handling jobs concurrently, and `OnChange` will be called once each time a new worker starts up. Our [Wasm implementation](https://github.com/suborbital/reactr/blob/master/rwasm/wasmrunnable.go) is a good example of this.
+The `Runnable` interface defines an `OnChange` function which gives the Runnable a chance to prepare itself for changes to the worker running it. For example, when a Runnable is registered with a pool size greater than 1, the Runnable may need to provision resources for itself to enable handling jobs concurrently, and `OnChange` will be called once each time a new worker starts up. Our [Wasm implementation](https://github.com/suborbital/reactr/blob/main/engine/wasmrunnable.go) is a good example of this.
 
 Most Runnables can return `nil` from this function, however returning an error will cause the worker start to be paused and retried until the required pool size has been acheived. The number of seconds between retries (default 3) and the maximum number of retries (default 5) can be configured when registering a Runnable:
+
 ```go
 doBad := r.Register("badRunner", badRunner{}, rt.RetrySeconds(1), rt.MaxRetries(10))
 ```
+
 Any error from a failed worker will be returned to the first job that is attempted for that Runnable.
 
 ### Pre-warming
+
 When a Runnable is mounted, it is simply registered as available to receive work. The Runnable is not actually invoked until the first job of the given type is received. For basic Runnables, this is normally fine, but for Runnables who use the `OnChange` method to provision resources, this can cause the first job to be slow. The `PreWarm` option is available to allow Runnables to be started as soon as they are mounted, rather than waiting for the first job. This mitigates cold-starts when anything expensive is needed at startup.
+
 ```go
 doExpensive := r.Register("expensive", expensiveRunnable{}, rt.PreWarm())
 ```
@@ -247,6 +278,7 @@ doExpensive := r.Register("expensive", expensiveRunnable{}, rt.PreWarm())
 ### Shortcuts
 
 There are also some shortcuts to make working with Reactr a bit easier:
+
 ```go
 type input struct {
 	First, Second int
@@ -261,6 +293,7 @@ func (g math) Run(job rt.Job, ctx *rt.Ctx) (interface{}, error) {
 	return in.First + in.Second, nil
 }
 ```
+
 ```go
 doMath := r.Register("math", math{})
 
@@ -269,6 +302,7 @@ for i := 1; i < 10; i++ {
 	fmt.Println("result", equals)
 }
 ```
+
 The `Register` function returns an optional helper function. Instead of passing a job name and full `Job` into `r.Do`, you can use the helper function to instead just pass the input data for the job, and you receive a `Result` as normal. `doMath`!
 
 ## Additional features

--- a/website/docs/reactr/wasm.md
+++ b/website/docs/reactr/wasm.md
@@ -6,19 +6,20 @@ The current supported languages are Rust (stable), TypeScript/AssemblyScript (be
 
 To create a Wasm runnable, check out the [subo CLI](https://github.com/suborbital/subo). Once you've generated a `.wasm` file, you can use it with Reactr just like any other Runnable!
 
-A multitude of example Runnables can be found in the [testdata directory](https://github.com/suborbital/reactr/tree/main/rwasm/testdata).
+A multitude of example Runnables can be found in the [testdata directory](https://github.com/suborbital/reactr/tree/main/engine/testdata).
 
 Due to the memory layout of WebAssembly, Wasm runners accept bytes (rather than arbitrary input) and return bytes. Reactr will handle the conversion of inputs and outputs automatically. Wasm runners cannot currently schedule other jobs.
 
-To get started with Wasm Runnables, install Reactr's WebAssembly package `rwasm`:
+To get started with Wasm Runnables, install Reactr's WebAssembly package `engine`:
+
 ```bash
-go get github.com/suborbital/reactr/rwasm
+go get github.com/suborbital/reactr/engine
 ```
 
 ```go
 r := rt.New()
 
-doWasm := r.Register("wasm", rwasm.NewRunner("path/to/runnable/file.wasm"))
+doWasm := r.Register("wasm", engine.NewRunner("path/to/runnable/file.wasm"))
 
 res, err := doWasm("input_will_be_converted_to_bytes").Then()
 if err != nil {

--- a/website/docs/sat/using-sat.md
+++ b/website/docs/sat/using-sat.md
@@ -1,27 +1,37 @@
 # Using Sat
 
 To run Sat, Docker is easiest:
+
 ```bash
-docker run -it -e SAT_HTTP_PORT=8080 -p 8080:8080 suborbital/sat:latest sat https://github.com/suborbital/reactr/blob/main/rwasm/testdata/hello-echo/hello-echo.wasm\?raw\=true
+docker run -it -e SAT_HTTP_PORT=8080 -p 8080:8080 suborbital/sat:latest sat https://raw.githubusercontent.com/suborbital/reactr/main/engine/testdata/hello-echo/hello-echo.wasm
 ```
+
 Sat will start up, download the `hello-echo` module from the `examples` directory, and make it available on port 8080. You can then make a POST request to `localhost:8080`, and the body will be echoed back to you.
+
 ```bash
 curl localhost:8080 -d 'my friend'
 ```
+
 Sat executes modules with the [Runnable API](https://atmo.suborbital.dev/runnable-api/introduction) enabled, so you can create modules using our [Subo CLI](https://github.com/suborbital/subo) and all of the capabilities are available for use.
 
 ## Stdin mode
+
 As an alternative to running Sat as a server, you can also use it in `stdin` mode. First, [build Sat](./building-sat.md).
 
 Then, run Sat with an input on stdin:
+
 ```bash
 echo "world" | .bin/sat --stdin ./examples/hello-echo/hello-echo.wasm
 ```
+
 Sat will write the result to stdout and exit.
 
 ## Run from URL
+
 If you provide a URL as the path argument to Sat, it will download the module from that URL, write it to a temp directory, and use it for execution:
+
 ```bash
-.bin/sat "https://github.com/suborbital/reactr/blob/main/rwasm/testdata/hello-echo/hello-echo.wasm?raw=true"
+.bin/sat "https://raw.githubusercontent.com/suborbital/reactr/main/engine/testdata/hello-echo/hello-echo.wasm"
 ```
+
 The URL must be HTTPS and must have a `.wasm` suffix (excluding query parameters).

--- a/website/docs/subo/usage.md
+++ b/website/docs/subo/usage.md
@@ -5,22 +5,26 @@ Subo includes the WebAssembly toolchain for Suborbital projects.
 The Suborbital Development Platform aims for Wasm to be a first-class citizen. `subo` is the toolchain for building Wasm Runnables for [Reactr](https://github.com/suborbital/reactr) and [Atmo](https://github.com/suborbital/atmo). The `subo` CLI can build Wasm Runnables, and can package several Wasm Runnables into a deployable Bundle.
 
 Building a Runnable in languages other than Go is designed to be simple and powerful:
+
 ```rust
 impl runnable::Runnable for Example {
     fn run(&self, input: Vec<u8>) -> Option<Vec<u8>> {
         let in_string = String::from_utf8(input).unwrap();
-    
+
         Some(String::from(format!("hello {}", in_string)).as_bytes().to_vec())
     }
 }
 ```
+
 subo will package your Runnable into a Wasm module that can be used by Reactr or Atmo and run just like any other Runnable! You can see examples of Runnables in the [test project](../test-project).
 
 ## Create a project
+
 To create a new project for Atmo or Reactr, use `subo create project <name>`. This will create a new folder which contains a Directive.yaml and an example Runnable.
 
 Full options for `create project`:
-```
+
+```console
 create a new project for Atmo or Reactr
 
 Usage:
@@ -33,14 +37,18 @@ Flags:
 ```
 
 ## Create a Runnable
+
 To create a new Runnable, use the create runnable command:
-```
+
+```console
 > subo create runnable <name>
 ```
+
 Rust is chosen by default, but if you prefer Swift, just pass `--lang=swift`! You can now use the Runnable API to build your function. A directory is created for each Runnable, and each contains a `.runnable.yaml` file that includes some metadata.
 
 The full options for `create runnable`:
-```
+
+```console
 Usage:
   subo create <name> [flags]
 
@@ -54,21 +62,26 @@ Flags:
 ```
 
 ## Building Wasm Runnables
+
 **It is reccomended that Docker be installed to build Wasm Runnables. See below if you do not have Docker installed.**
- 
+
 To build your Runnable into a Wasm module for Reactr or Atmo, use the build command:
-```
+
+```console
 > subo build .
 ```
+
 If the current working directory is a Runnable, subo will build it. If the current directory contains many runnables, subo will build them all. Any directory with a `.runnable.yaml` file is considered a Runnable and will be built. Building Runnables is not fully tested on Windows.
 
 ## Bundles
+
 By default, subo will write all of the Runnables in the current directory into a Bundle. Atmo uses Runnable Bundles to help you build powerful web services by composing Runnables declaratively. If you want to skip bundling, you can pass `--no-bundle` to `subo build`
 
-The resulting Bundle can also be used with a Reactr instance by calling `h.HandleBundle({path/to/bundle})`. See the [Reactr Wasm instructions](https://github.com/suborbital/reactr/blob/master/docs/wasm.md) for details.
+The resulting Bundle can also be used with a Reactr instance by calling `h.HandleBundle({path/to/bundle})`. See the [Reactr Wasm instructions](../reactr/wasm.md) for details.
 
 The full options for `build`:
-```
+
+```console
 Usage:
   subo build [dir] [flags]
 
@@ -85,20 +98,25 @@ Flags:
 ```
 
 ## Building without Docker
+
 If you prefer not to use Docker, you can use the `--native` flag. This will cause subo to use your local machine's toolchain to build Runnables instead of Docker containers. You will need to install the toolchains yourself:
+
 - Rust: Install the latest Rust toolchain and [the additional `wasm32-wasi` target](https://bytecodealliance.github.io/cargo-wasi/steps.html#managing-the-wasm32-wasi-target).
 - Swift: Install the [SwiftWasm](https://book.swiftwasm.org/getting-started/setup.html) toolchain. If using macOS, ensure XCode developer tools are installed (xcrun is required).
 
 `subo` is continually evolving alongside [Reactr](https://github.com/suborbital/reactr) and [Atmo](https://github.com/suborbital/atmo).
 
 ## Suborbital Runnable API
+
 Reactr and Atmo provide an [API](https://atmo.suborbital.dev/runnable-api/introduction) which gives Wasm Runnables the ability to access resources and communicate with the host application. This API currently has capabilities such as:
+
 - The ability to make HTTP requests
 - Structured logging
 - Access to persistent cache
 - Access to a static filesystem
 
 This API will soon have:
+
 - The ability to render templates
 - Database access
 - Access to blob storage


### PR DESCRIPTION
Reactr's `rwasm` package has been renamed to `engine`

- Renames `rwasm` to `engine` and removes `rwasm` from the dictionary
- Fixes some of the markdown lint errors (new line spacing mostly)
- Renames references from `master` to `main`
