### PR TITLE
fix: document WasmEdge version dependency

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -382,6 +382,8 @@ runnables
 Runnables
 runtime
 Runtime
+runtimes
+Runtimes
 RVG
 SaaS
 sandboxed

--- a/spelling.dic
+++ b/spelling.dic
@@ -496,6 +496,7 @@ wasi
 WASI
 wasm
 Wasm
+WasmEdge
 Wasmer
 wasmrunnable
 wasmtime

--- a/website/docs/reactr/reactr.md
+++ b/website/docs/reactr/reactr.md
@@ -10,15 +10,6 @@ pagination_prev: null
 
 ### The Basics
 
-:::note
-Reactr uses the Wasmer runtime by default, but supports the 
-Wasmtime and WasmEdge runtimes as well (Wasmtime is not yet supported on 
-ARM). To use WasmEdge, specify version WasmEdge-go@v0.9.
-
-To use Wasmtime or WasmEdge, pass `-tags wasmtime` or `-tags wasmedge` to any 
-`go` command.
-:::
-
 First, install Reactr's core package `rt`:
 
 ```bash
@@ -322,3 +313,12 @@ The `Register` function returns an optional helper function. Instead of passing 
 Reactr can integrate with [Grav](https://github.com/suborbital/grav), which is the decentralized message bus developed as part of the Suborbital Development Platform. Read about the integration on [the grav documentation page.](./grav.md)
 
 Reactr provides the building blocks for scalable asynchronous systems. This should be everything you need to help you improve the performance of your application. When you are looking to take advantage of Reactr's other features, check out its [Wasm](./wasm.md) capabilities!
+
+## Alternative runtimes
+
+Reactr uses the Wasmer runtime by default, but supports the 
+Wasmtime and WasmEdge runtimes as well. To use WasmEdge, install the  
+[version of WasmEdge used by Reactr](https://github.com/suborbital/reactr/blob/b3f435231d3bb51b1328b8c12ccdc7d0fb42ef62/go.mod#L13).
+
+To use Wasmtime or WasmEdge, pass `-tags wasmtime` or `-tags wasmedge` to any 
+`go` command.

--- a/website/docs/reactr/reactr.md
+++ b/website/docs/reactr/reactr.md
@@ -10,6 +10,10 @@ pagination_prev: null
 
 ### The Basics
 
+:::note
+Reactr depends on WasmEdge-go@v0.9
+:::
+
 First, install Reactr's core package `rt`:
 
 ```bash

--- a/website/docs/reactr/reactr.md
+++ b/website/docs/reactr/reactr.md
@@ -11,7 +11,12 @@ pagination_prev: null
 ### The Basics
 
 :::note
-Reactr depends on WasmEdge-go@v0.9
+Reactr uses the Wasmer runtime by default, but supports the 
+Wasmtime and WasmEdge runtimes as well (Wasmtime is not yet supported on 
+ARM). To use WasmEdge, specify version WasmEdge-go@v0.9.
+
+To use Wasmtime or WasmEdge, pass `-tags wasmtime` or `-tags wasmedge` to any 
+`go` command.
 :::
 
 First, install Reactr's core package `rt`:

--- a/website/docs/reactr/wasm.md
+++ b/website/docs/reactr/wasm.md
@@ -29,6 +29,4 @@ if err != nil {
 fmt.Println(string(res.([]byte)))
 ```
 
-By default, Reactr uses the Wasmer runtime internally, but supports the Wasmtime runtime as well. Pass `-tags wasmtime` to any `go` command to use Wasmtime. Wasmtime is not yet supported on ARM.
-
 And that's it! You can schedule Wasm jobs as normal, and Wasm environments will be managed automatically to run your jobs.


### PR DESCRIPTION
Closes #145. I copied the callout syntax from another page of ours, and maybe it's specific to Docusaurus because it doesn't display as a callout box with regular Markdown?