### PR TITLE
ci(accessibility): update action @v1.11.0

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: A11yWatch/github-action@v1.5.1
+      - uses: A11yWatch/github-action@v1.11.0
         with:
           WEBSITE_URL: https://docs.suborbital.dev
           FAIL_ERRORS_COUNT: 3


### PR DESCRIPTION
* updates compatibility with containers required for action


-- Notes

If CI fails to run the action the `UPGRADE` flag is required to update the system dependencies for the system. After toggling `UPGRADE=true` and a successful action run it can be removed.

Currently the action is set to only run on the root page of the domain set. If we want a full site run we can use the `SITE_WIDE: true` flag.