### PR TITLE
fix link to get started from se2 landing page

### DIFF
--- a/website/docs/se2/se2.md
+++ b/website/docs/se2/se2.md
@@ -9,7 +9,7 @@ Suborbital Extension Engine (SE2) is a platform that allows your users to write 
 plugins that integrate into your app. Our WebAssembly-based runtime lets you run user 
 code within your infrastructure while being sure you're protected from malicious code.
 
-SE2 is now in public beta! We are excited for you to [give it a try](get-started)
+SE2 is now in public beta! We are excited for you to [give it a try](./get-started.md)
 and send us your feedback. 
 
 SE2 gives you everything you need to run your users' plugins in a secure sandbox and integrate them into your product in 


### PR DESCRIPTION
Currently the link to "Get Started" on the [SE2 landing page](https://docs.suborbital.dev/) gives "Page Not Found" if you arrive at the SE2 landing page from the docs homepage, but not if you arrive at it from the sidebar link, because coming from the docs homepage the link is https://docs.suborbital.dev/get-started but coming from the sidebar the link is https://docs.suborbital.dev/se2/get-started. 

The tidy fix would change ```<Link to={useBaseUrl('se2')}>``` in [Header.jsx](https://github.com/suborbital/docs/blob/main/website/src/components/sections/Header.jsx), but for the moment we'll just do this.