### PR TITLE
fix: Redirect broken quickstart link to docs index

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    { 
+      "source": "/se2/get-started",
+      "destination": "/", 
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
Some automated onboarding emails included a link to /se2/get-started, which 404's. This commit redirects that URL to the docs index.

The redirect is temporary (307) instead of permanent (308) since I can imagine us actually wanting a page at /se2/get-started in the future.